### PR TITLE
Refactor webpack file

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -7,148 +7,35 @@
  * https://webpack.js.org/configuration/
  */
 
-var path = require('path');
 var webpack = require('webpack');
 var ionicWebpackFactory = require(process.env.IONIC_WEBPACK_FACTORY);
 
 var ModuleConcatPlugin = require('webpack/lib/optimize/ModuleConcatenationPlugin');
 var PurifyPlugin = require('@angular-devkit/build-optimizer').PurifyPlugin;
 
-var optimizedProdLoaders = [
-  {
-    test: /\.json$/,
-    loader: 'json-loader'
-  },
-  {
-    test: /\.js$/,
-    loader: [
-      {
-        loader: process.env.IONIC_CACHE_LOADER
-      },
+var useDefaultConfig = require('@ionic/app-scripts/config/webpack.config.js');
 
-      {
-        loader: '@angular-devkit/build-optimizer/webpack-loader',
-        options: {
-          sourceMap: true
-        }
-      },
-    ]
-  },
-  {
-    test: /\.ts$/,
-    loader: [
-      {
-        loader: process.env.IONIC_CACHE_LOADER
-      },
+useDefaultConfig.dev.plugins = [
+  ionicWebpackFactory.getIonicEnvironmentPlugin(),
+  ionicWebpackFactory.getCommonChunksPlugin(),
+  new webpack.NormalModuleReplacementPlugin(/typeorm$/, function (result) {
+    result.request = result.request.replace(/typeorm/, "typeorm/browser");
+  }),
+  new webpack.ProvidePlugin({
+    'window.SQL': 'sql.js/js/sql.js'
+  })
+]
 
-      {
-        loader: '@angular-devkit/build-optimizer/webpack-loader',
-        options: {
-          sourceMap: true
-        }
-      },
+useDefaultConfig.prod.plugins = [
+  ionicWebpackFactory.getIonicEnvironmentPlugin(),
+  ionicWebpackFactory.getCommonChunksPlugin(),
+  new ModuleConcatPlugin(),
+  new PurifyPlugin(),
+  new webpack.NormalModuleReplacementPlugin(/typeorm$/, function (result) {
+    result.request = result.request.replace(/typeorm/, "typeorm/browser");
+  })
+]
 
-      {
-        loader: process.env.IONIC_WEBPACK_LOADER
-      }
-    ]
-  }
-];
-
-function getProdLoaders() {
-  if (process.env.IONIC_OPTIMIZE_JS === 'true') {
-    return optimizedProdLoaders;
-  }
-  return devConfig.module.loaders;
-}
-
-var devConfig = {
-  entry: process.env.IONIC_APP_ENTRY_POINT,
-  output: {
-    path: '{{BUILD}}',
-    publicPath: 'build/',
-    filename: '[name].js',
-    devtoolModuleFilenameTemplate: ionicWebpackFactory.getSourceMapperFunction(),
-  },
-  devtool: process.env.IONIC_SOURCE_MAP_TYPE,
-
-  resolve: {
-    extensions: ['.ts', '.js', '.json'],
-    modules: [path.resolve('node_modules')]
-  },
-
-  module: {
-    loaders: [
-      {
-        test: /\.json$/,
-        loader: 'json-loader'
-      },
-      {
-        test: /\.ts$/,
-        loader: process.env.IONIC_WEBPACK_LOADER
-      }
-    ]
-  },
-
-  plugins: [
-    ionicWebpackFactory.getIonicEnvironmentPlugin(),
-    ionicWebpackFactory.getCommonChunksPlugin(),
-    new webpack.NormalModuleReplacementPlugin(/typeorm$/, function (result) {
-      result.request = result.request.replace(/typeorm/, "typeorm/browser");
-    }),
-    new webpack.ProvidePlugin({
-      'window.SQL': 'sql.js/js/sql.js'
-    })
-  ],
-
-  // Some libraries import Node modules but don't use them in the browser.
-  // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty'
-  }
+module.exports = function () {
+  return useDefaultConfig;
 };
-
-var prodConfig = {
-  entry: process.env.IONIC_APP_ENTRY_POINT,
-  output: {
-    path: '{{BUILD}}',
-    publicPath: 'build/',
-    filename: '[name].js',
-    devtoolModuleFilenameTemplate: ionicWebpackFactory.getSourceMapperFunction(),
-  },
-  devtool: process.env.IONIC_SOURCE_MAP_TYPE,
-
-  resolve: {
-    extensions: ['.ts', '.js', '.json'],
-    modules: [path.resolve('node_modules')]
-  },
-
-  module: {
-    loaders: getProdLoaders()
-  },
-
-  plugins: [
-    ionicWebpackFactory.getIonicEnvironmentPlugin(),
-    ionicWebpackFactory.getCommonChunksPlugin(),
-    new ModuleConcatPlugin(),
-    new PurifyPlugin(),
-    new webpack.NormalModuleReplacementPlugin(/typeorm$/, function (result) {
-      result.request = result.request.replace(/typeorm/, "typeorm/browser");
-    })
-  ],
-
-  // Some libraries import Node modules but don't use them in the browser.
-  // Tell Webpack to provide empty mocks for them so importing them works.
-  node: {
-    fs: 'empty',
-    net: 'empty',
-    tls: 'empty'
-  }
-};
-
-module.exports = {
-  dev: devConfig,
-  prod: prodConfig
-}


### PR DESCRIPTION
	* Refactor webpack to only extends current webpack file from
	ionic with purpose to not touch modules which persistence
	does not need update. So all others modules than plugin could
	be updated according ionic cycle.